### PR TITLE
uart: fix bug in uart_init

### DIFF
--- a/modules/uart/src/uart.c
+++ b/modules/uart/src/uart.c
@@ -83,7 +83,7 @@ void uart_set_gpio(int port) {
     }
 }
 struct uart_control *uart_init(int port, int set_gpio) {
-    if (!(port <= 0 && port <= 5)) {
+    if (!(port >= 0 && port <= 5)) {
         return (struct uart_control *)0; 
     }
     /// set clock 


### PR DESCRIPTION
Port number check should be `0 <= port <= 5`. This PR fixes that.